### PR TITLE
Delta ean

### DIFF
--- a/src/asset/asset_data.py
+++ b/src/asset/asset_data.py
@@ -405,10 +405,10 @@ def insert_department_ean_from_delta():
     try:
         logger.info("Fetching department EAN numbers from Delta...")
         res = delta_client.get_all_adm_units_with_children_and_ean()
-        logger.info(f"Found {len(res)} departments with EAN numbers from Delta.")
         if not res:
             logger.error("No departments/EAN numbers fetched from Delta.")
             return False
+        logger.info(f"Found {len(res)} departments with EAN numbers from Delta.")
 
         with asset_db_client.get_session() as session:
             departments = session.query(Department).all()

--- a/src/asset/asset_data.py
+++ b/src/asset/asset_data.py
@@ -8,15 +8,18 @@ from utils.database_connection import get_asset_db, get_capa_cms_db
 from utils.sftp_connection import get_asset_sftp_client
 from asset.model import Base
 from asset.model import Department, User, Computer
+from delta_client import DeltaClient
 from utils.api_requests import APIClient
 from utils.config import (
-    ASSET_SFTP_AFDELINGS_EAN_DELTA_FILE_PATH, ASSET_SFTP_DEVICE_FILE_PATH, ASSET_SFTP_COMM2IG_HISTORICAL_FILE_PATH, ASSET_SFTP_EAN_ATEA_FILE_PATH,
-    ATEA_API_KEY, ATEA_URL, TOPDESK_API_USERNAME, TOPDESK_API_PASSWORD, TOPDESK_API_URL, TOPDESK_ASSET_FILENAME,
+    ASSET_SFTP_DEVICE_FILE_PATH, ASSET_SFTP_COMM2IG_HISTORICAL_FILE_PATH, ASSET_SFTP_EAN_ATEA_FILE_PATH,
+    ATEA_API_KEY, ATEA_URL, DELTA_AUTH_URL, DELTA_CLIENT_ID, DELTA_CLIENT_SECRET, DELTA_REALM, DELTA_URL, TOPDESK_API_USERNAME, TOPDESK_API_PASSWORD, TOPDESK_API_URL, TOPDESK_ASSET_FILENAME,
+
 )
 from utils.utils import df_to_csv_bytes
 
 logger = logging.getLogger(__name__)
 
+delta_client = DeltaClient(base_url=DELTA_URL, auth_url=DELTA_AUTH_URL, realm=DELTA_REALM, client_id=DELTA_CLIENT_ID, client_secret=DELTA_CLIENT_SECRET)
 atea_client = APIClient(base_url=ATEA_URL, api_key=ATEA_API_KEY, use_subkey=True)
 topdesk_client = APIClient(base_url=TOPDESK_API_URL, username=TOPDESK_API_USERNAME, password=TOPDESK_API_PASSWORD)
 capa_cms_db_client = get_capa_cms_db()
@@ -307,8 +310,6 @@ def insert_device_license_and_historical_data():
         with sftp_client.get_connection() as conn:
             with conn.open(ASSET_SFTP_DEVICE_FILE_PATH, 'r') as file:
                 device_license_csv_data = file.read().decode('utf-8')
-            with conn.open(ASSET_SFTP_AFDELINGS_EAN_DELTA_FILE_PATH, 'rb') as file:
-                afdelings_ean_excel_data = file.read()
             with conn.open(ASSET_SFTP_COMM2IG_HISTORICAL_FILE_PATH, 'r') as file:
                 comm2ig_csv_data = file.read().decode('utf-8')
             with conn.open(ASSET_SFTP_EAN_ATEA_FILE_PATH, 'rb') as file:
@@ -320,12 +321,6 @@ def insert_device_license_and_historical_data():
             logger.error("CSV is missing 'Name' column.")
             return False
         computer_names = [name.strip() for name in df_device_license['Name'].dropna().tolist()]
-
-        df_afdelings_ean = pd.read_excel(io.BytesIO(afdelings_ean_excel_data), dtype=str)
-        df_afdelings_ean.columns = df_afdelings_ean.columns.str.strip()
-        if 'Institution/afdeling' not in df_afdelings_ean.columns or 'Ean-nummer' not in df_afdelings_ean.columns:
-            logger.error("Exel is missing 'Institution/afdeling' or 'Ean-nummer' column.")
-            return False
 
         df_comm2ig = pd.read_csv(io.StringIO(comm2ig_csv_data), dtype=str, sep=',')
         df_comm2ig.columns = df_comm2ig.columns.str.strip()
@@ -361,22 +356,6 @@ def insert_device_license_and_historical_data():
                 if computer:
                     computer.device_license = True
                     updated_device += 1
-
-            departments = session.query(Department).all()
-            department_lookup = {a.name: a for a in departments if a.name}
-
-            # AfdelingsEAN/Delta
-            updated_ean = 0
-            for _, row in df_afdelings_ean.iterrows():
-                department = str(row['Institution/afdeling']).strip().lower()
-                ean_nummer = str(row['Ean-nummer']).strip()
-                if not ean_nummer or ean_nummer.lower() == 'nan':
-                    logger.info(f"Skipping update for Department: {department} as Ean-nummer is empty.")
-                    continue
-                department_obj = department_lookup.get(department)
-                if department_obj:
-                    department_obj.ean = ean_nummer
-                    updated_ean += 1
 
             # Comm2ig historisk data
             updated_comm2ig = 0
@@ -414,12 +393,44 @@ def insert_device_license_and_historical_data():
 
             session.commit()
             logger.info(f"DeviceLicense updated for {updated_device} computers")
-            logger.info(f"AfdelingsEAN updated for {updated_ean} departments")
             logger.info(f"Comm2ig Historical data: Updated price, order date, and kob_ean_nr for {updated_comm2ig} serial numbers.")
             logger.info(f"Atea: kob_ean_nr updated for {updated_atea}")
         return True
     except Exception as e:
-        logger.error(f"Error with updating DeviceLicense, AfdelingsEAN, Comm2ig or Atea data: {e}")
+        logger.error(f"Error with updating DeviceLicense, Comm2ig or Atea data: {e}")
+        return False
+
+
+def insert_department_ean_from_delta():
+    try:
+        logger.info("Fetching department EAN numbers from Delta...")
+        res = delta_client.get_all_adm_units_with_children_and_ean()
+        logger.info(f"Found {len(res)} departments with EAN numbers from Delta.")
+        if not res:
+            logger.error("No departments/EAN numbers fetched from Delta.")
+            return False
+
+        with asset_db_client.get_session() as session:
+            departments = session.query(Department).all()
+            department_lookup = {d.name: d for d in departments if d.name}
+            updated = 0
+
+            for adm in res:
+                name = str(adm.get("name", "")).strip().lower()
+                ean = adm.get("ean", None)
+                if not name:
+                    continue
+                if ean and str(ean).strip().lower() != "nan":
+                    department_obj = department_lookup.get(name)
+                    if department_obj:
+                        department_obj.ean = str(ean).strip()
+                        updated += 1
+
+            session.commit()
+            logger.info(f"Updated EAN number for {updated} departments from Delta.")
+        return True
+    except Exception as e:
+        logger.error(f"Error updating department EAN from Delta: {e}")
         return False
 
 

--- a/src/delta_client.py
+++ b/src/delta_client.py
@@ -923,3 +923,161 @@ class DeltaClient(APIClient):
                 logger.warning(f"SD Department ID mismatch: delta: {sd_department_id_delta}, sd: {sd_department_id}")
 
         return employees
+
+    def get_all_adm_units_with_children_and_ean(self):
+        results = []
+        offset = 0
+        limit = 1000
+
+        while True:
+            grapgh_query = {
+                "graphQueries": [
+                    {
+                        "computeAvailablePages": True,
+                        "graphQuery": {
+                            "structure": {
+                                "alias": "adm",
+                                "userKey": "APOS-Types-AdministrativeUnit"
+                            },
+                            "criteria": {
+                                "type": "AND",
+                                "criteria": [
+                                    {
+                                        "type": "MATCH",
+                                        "operator": "EQUAL",
+                                        "left": {
+                                            "source": "DEFINITION",
+                                            "alias": "adm.$state"
+                                        },
+                                        "right": {
+                                            "source": "STATIC",
+                                            "value": "STATE_ACTIVE"
+                                        }
+                                    }
+                                ]
+                            },
+                            "projection": {
+                                "identity": True,
+                                "attributes": [
+                                    "APOS-Types-AdministrativeUnit-Attribute-EANnr"
+                                ],
+                                "children": {
+                                    "identity": True,
+                                    "attributes": [
+                                        "APOS-Types-AdministrativeUnit-Attribute-EANnr"
+                                    ]
+                                }
+                            }
+                        },
+                        "validDate": "NOW",
+                        "offset": offset,
+                        "limit": limit
+                    }
+                ]
+            }
+
+            res = self.make_request(path='/api/object/graph-query', method='POST', json=grapgh_query)
+            graph_result = res["graphQueryResult"][0]
+            available_pages = graph_result.get("availablePages", 0)
+            instances = graph_result.get("instances", [])
+
+            for inst in instances:
+                parent_name = inst.get('identity', {}).get('name', '')
+                parent_ean = next(
+                    (att['value'] for att in inst.get('attributes', []) if att['userKey'] == 'APOS-Types-AdministrativeUnit-Attribute-EANnr'),
+                    None
+                )
+                logger.debug(f"Parent: {parent_name}, EAN: {parent_ean}")
+                children = inst.get('childrenObjects', [])
+                for child in children:
+                    name = child.get('identity', {}).get('name', '')
+                    ean = next(
+                        (att['value'] for att in child.get('attributes', []) if att['userKey'] == 'APOS-Types-AdministrativeUnit-Attribute-EANnr'),
+                        None
+                    )
+                    if not ean and parent_ean:
+                        ean = parent_ean
+                        logger.debug(f"Child: {name} inherits parent EAN: {ean} from parent: {parent_name}")
+                    else:
+                        logger.debug(f"Child: {name}, EAN: {ean}")
+                    results.append({
+                        'parent': parent_name,
+                        'name': name,
+                        'ean': ean
+                    })
+
+            total_instances = available_pages * limit
+            if offset + limit >= total_instances or len(instances) < limit:
+                break
+
+            offset += limit
+
+        return results
+
+    def get_all_adm_units_with_ean(self):
+        results = []
+        offset = 0
+        limit = 1000
+
+        while True:
+            grapgh_query = {
+                "graphQueries": [
+                    {
+                        "computeAvailablePages": True,
+                        "graphQuery": {
+                            "structure": {
+                                "alias": "adm",
+                                "userKey": "APOS-Types-AdministrativeUnit"
+                            },
+                            "criteria": {
+                                "type": "AND",
+                                "criteria": [
+                                    {
+                                        "type": "MATCH",
+                                        "operator": "EQUAL",
+                                        "left": {
+                                            "source": "DEFINITION",
+                                            "alias": "adm.$state"
+                                        },
+                                        "right": {
+                                            "source": "STATIC",
+                                            "value": "STATE_ACTIVE"
+                                        }
+                                    }
+                                ]
+                            },
+                            "projection": {
+                                "identity": True,
+                                "attributes": [
+                                    "APOS-Types-AdministrativeUnit-Attribute-EANnr"
+                                ]
+                            }
+                        },
+                        "validDate": "NOW",
+                        "offset": offset,
+                        "limit": limit
+                    }
+                ]
+            }
+
+            res = self.make_request(path='/api/object/graph-query', method='POST', json=grapgh_query)
+            graph_result = res["graphQueryResult"][0]
+            available_pages = graph_result.get("availablePages", 0)
+            instances = graph_result.get("instances", [])
+
+            for inst in instances:
+                name = inst.get('identity', {}).get('name', None)
+                attributes = inst.get('attributes', [])
+                ean = next(
+                    (att['value'] for att in attributes if att['userKey'] == 'APOS-Types-AdministrativeUnit-Attribute-EANnr'),
+                    None
+                )
+                results.append({"name": name, "ean": ean})
+
+            total_instances = available_pages * limit
+            if offset + limit >= total_instances or len(instances) < limit:
+                break
+
+            offset += limit
+
+        return results

--- a/src/delta_client.py
+++ b/src/delta_client.py
@@ -930,7 +930,7 @@ class DeltaClient(APIClient):
         limit = 1000
 
         while True:
-            grapgh_query = {
+            graph_query = {
                 "graphQueries": [
                     {
                         "computeAvailablePages": True,
@@ -976,7 +976,7 @@ class DeltaClient(APIClient):
                 ]
             }
 
-            res = self.make_request(path='/api/object/graph-query', method='POST', json=grapgh_query)
+            res = self.make_request(path='/api/object/graph-query', method='POST', json=graph_query)
             graph_result = res["graphQueryResult"][0]
             available_pages = graph_result.get("availablePages", 0)
             instances = graph_result.get("instances", [])
@@ -1005,74 +1005,6 @@ class DeltaClient(APIClient):
                         'name': name,
                         'ean': ean
                     })
-
-            total_instances = available_pages * limit
-            if offset + limit >= total_instances or len(instances) < limit:
-                break
-
-            offset += limit
-
-        return results
-
-    def get_all_adm_units_with_ean(self):
-        results = []
-        offset = 0
-        limit = 1000
-
-        while True:
-            grapgh_query = {
-                "graphQueries": [
-                    {
-                        "computeAvailablePages": True,
-                        "graphQuery": {
-                            "structure": {
-                                "alias": "adm",
-                                "userKey": "APOS-Types-AdministrativeUnit"
-                            },
-                            "criteria": {
-                                "type": "AND",
-                                "criteria": [
-                                    {
-                                        "type": "MATCH",
-                                        "operator": "EQUAL",
-                                        "left": {
-                                            "source": "DEFINITION",
-                                            "alias": "adm.$state"
-                                        },
-                                        "right": {
-                                            "source": "STATIC",
-                                            "value": "STATE_ACTIVE"
-                                        }
-                                    }
-                                ]
-                            },
-                            "projection": {
-                                "identity": True,
-                                "attributes": [
-                                    "APOS-Types-AdministrativeUnit-Attribute-EANnr"
-                                ]
-                            }
-                        },
-                        "validDate": "NOW",
-                        "offset": offset,
-                        "limit": limit
-                    }
-                ]
-            }
-
-            res = self.make_request(path='/api/object/graph-query', method='POST', json=grapgh_query)
-            graph_result = res["graphQueryResult"][0]
-            available_pages = graph_result.get("availablePages", 0)
-            instances = graph_result.get("instances", [])
-
-            for inst in instances:
-                name = inst.get('identity', {}).get('name', None)
-                attributes = inst.get('attributes', [])
-                ean = next(
-                    (att['value'] for att in attributes if att['userKey'] == 'APOS-Types-AdministrativeUnit-Attribute-EANnr'),
-                    None
-                )
-                results.append({"name": name, "ean": ean})
 
             total_instances = available_pages * limit
             if offset + limit >= total_instances or len(instances) < limit:

--- a/src/jobs/asset.py
+++ b/src/jobs/asset.py
@@ -1,7 +1,7 @@
 import logging
 from asset.asset_data import (
     create_asset_tables, insert_departments_data, insert_users_data, insert_computers_data,
-    insert_device_license_and_historical_data, insert_atea_data, upload_assets_to_topdesk
+    insert_device_license_and_historical_data, insert_atea_data, upload_assets_to_topdesk, insert_department_ean_from_delta
 )
 
 logger = logging.getLogger(__name__)
@@ -15,6 +15,10 @@ def job():
 
         if not insert_departments_data():
             logger.error("Failed to insert departments data.")
+            return False
+
+        if not insert_department_ean_from_delta():
+            logger.error("Failed to insert department EAN data from Delta.")
             return False
 
         if not insert_users_data():

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -181,7 +181,6 @@ ATEA_URL = os.environ['ATEA_URL'].rstrip()
 ASSET_SFTP_DEVICE_FILE_PATH = 'Computers.csv'
 ASSET_SFTP_COMM2IG_HISTORICAL_FILE_PATH = '/Historisk_data/Historisk_Comm2ig.csv'
 ASSET_SFTP_EAN_ATEA_FILE_PATH = '/Historisk_data/ATEA kundenumre med EAN.xlsx'
-ASSET_SFTP_AFDELINGS_EAN_DELTA_FILE_PATH = '/Historisk_data/Afdeling_EAN_Delta.xlsx'
 
 TOPDESK_API_USERNAME = os.getenv("TOPDESK_API_USERNAME")
 TOPDESK_API_PASSWORD = os.getenv("TOPDESK_API_PASSWORD")


### PR DESCRIPTION
### delta_client.py:
- Tilføjet funktionen get_all_adm_units_with_children_and_ean som henter alle adm enheder fra Delta, samt deres underenheder(child), og returnerer en liste med navn og EAN-nummer for både forældre og børn. Hvis en underenhed ikke har et EAN-nummer, arver den forældrens EAN-nummer.

- Tilføjet funktionen get_all_adm_units_with_ean() som henter alle adm enheder hvis de har en ean.

I Delta har jeg tilføjet alle de afdelings-EAN-numre fra Excel-arket, som manglede i Delta. Der var dog 6-7 afdelinger i Excel-arket, som ikke fandtes i Delta.

**Asset Data**
- Afdeling EAN nr hentes nu fra Delta API'et i stedet for SFTP'en